### PR TITLE
fix |failed deprecation warnings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,14 +15,14 @@
   file:
     path: /usr/local/go
     state: absent
-  when: go_version|failed or go_version.stdout != go_version_target
+  when: go_version is failed or go_version.stdout != go_version_target
 
 - name: Extract the Go tarball if Go is not yet installed or not the desired version
   unarchive:
     src: /usr/local/src/{{ go_tarball }}
     dest: /usr/local
     copy: no
-  when: go_version|failed or go_version.stdout != go_version_target
+  when: go_version is failed or go_version.stdout != go_version_target
 
 - name: Add the Go bin directory to the PATH environment variable for all users
   copy:


### PR DESCRIPTION
there are a couple of them, to be removed in 2.9.